### PR TITLE
Update db query string

### DIFF
--- a/flask_app/models/writing.py
+++ b/flask_app/models/writing.py
@@ -9,6 +9,6 @@ class Writing:
 
     @classmethod
     def save( cls, data ):
-        query_string = "INSERT INTO writings ( title, description, content ) \
+        query_string = "INSERT INTO creations ( title, description, writing ) \
             VALUES (%(title)s, %(description)s, %(content)s);"
         return connectToMySQL().query_db(query_string, data)


### PR DESCRIPTION
After successfully connecting to the database, it returned an error first indicating that the "writings" table (should have been "creations") did not exist, and then that the "content" column (should have been "writing") did not exist.

This was an oversight on my part.

This PR is simply for database connection proof of concept. See changes to db query string updating table name and writing column name.