### PR TITLE
Change writings.field_name to writing.field_name

### DIFF
--- a/flask_app/templates/view-writing.html
+++ b/flask_app/templates/view-writing.html
@@ -2,11 +2,11 @@
 <html lang="en-US">
 <head>
     <meta charset="utf-8">
-    <title>{{writings.name}}</title>
-    <meta name="description" content="{{writings.description}}">
+    <title>{{writing.name}}</title>
+    <meta name="description" content="{{writing.description}}">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <meta property="og:title" content={{writings.name}}>
+    <meta property="og:title" content={{writing.name}}>
     <meta property="og:type" content="article">
     <meta property="og:url" content="../w">
     <meta property="og:image" content="{{ url_for('static', filename='assets/images/fire.png') }}">
@@ -22,9 +22,9 @@
 <body>
     <div class="content-container">
         <a class="nav-back" href="/w">‹</a>
-        <h1>{{writings.name}}</h1>
-        <h2>{{writings.time_s}}</h2>
-        <p>{{writings.writing}}</p>
+        <h1>{{writing.name}}</h1>
+        <h2>{{writing.time_s}}</h2>
+        <p>{{writing.writing}}</p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
I noticed that the view writing page was giving an error, upon investigation I found that "writing" was being passed to the view-writing.html template, but all references to this within the template were to "writings", thus giving an error.

Make a quick fix to this typo.