### PR TITLE
Add time utility to display utc_s as time string

### DIFF
--- a/flask_app/models/creature.py
+++ b/flask_app/models/creature.py
@@ -1,4 +1,5 @@
 from flask_app.config.mysqlconnection import connectToMySQL
+from flask_app.utilities.time_util import utc_sec_to_date_time
 
 class Creature:
     def __init__( self, data ):
@@ -34,6 +35,10 @@ class Creature:
             res_url_str += word
 
         return res_url_str
+
+    @property
+    def time_string( self ):
+        return utc_sec_to_date_time(self.time_s)
 
     @classmethod
     def get_all( cls ):

--- a/flask_app/models/writing.py
+++ b/flask_app/models/writing.py
@@ -1,4 +1,5 @@
 from flask_app.config.mysqlconnection import connectToMySQL
+from flask_app.utilities.time_util import utc_sec_to_date_time
 
 class Writing:
     def __init__( self, data ):
@@ -34,6 +35,10 @@ class Writing:
             res_url_str += word
 
         return res_url_str
+    
+    @property
+    def time_string( self ):
+        return utc_sec_to_date_time(self.time_s)
 
     @classmethod
     def get_all( cls ):

--- a/flask_app/templates/view-creature.html
+++ b/flask_app/templates/view-creature.html
@@ -29,7 +29,7 @@
         <h1>{{creature.name}}</h1>
         <!--<img src="{{ url_for('static', filename='assets/images/leaf.png') }}" alt="a {{creature.name}}"><br>-->
         <em>{{creature.name_scientific}}</em><br>
-        <em>{{creature.time_s}} seconds since epoch</em><br>
+        <em>{{creature.time_string}}</em><br>
         <em>{{creature.lat_deg}}, {{creature.long_deg}}, {{creature.elev_m}}m [wgs84]</em><br><br>
         {{creature.description}}
     </div>

--- a/flask_app/templates/view-writing.html
+++ b/flask_app/templates/view-writing.html
@@ -23,7 +23,7 @@
     <div class="content-container">
         <a class="nav-back" href="/w">‹</a>
         <h1>{{writing.name}}</h1>
-        <h2>{{writing.time_s}}</h2>
+        <h2>{{writing.time_string}}</h2>
         <p>{{writing.writing}}</p>
     </div>
 </body>

--- a/flask_app/utilities/time_util.py
+++ b/flask_app/utilities/time_util.py
@@ -1,0 +1,56 @@
+from time import gmtime, strftime
+
+
+def utc_sec_to_date_time( utc_sec ):
+    if not utc_sec:
+        return ""
+    
+    # convert utc seconds to time structure
+    utc_time_fields = gmtime(utc_sec)
+
+    # parse individual fields to desired formatting
+    year = utc_time_fields.tm_year
+    month_name = strftime("%B", utc_time_fields).lower()
+    day_of_month = format_day_of_month(utc_time_fields.tm_mday)
+    hours = format_hours_remove_leading_zero( strftime("%I", utc_time_fields ))
+    minutes = strftime("%M", utc_time_fields)
+    am_pm = strftime("%p", utc_time_fields).lower()
+
+    # then recombine into formatted string
+    res_time_string = f'{year}, {month_name} {day_of_month}, \
+        {hours}:{minutes} {am_pm} [utc]'
+
+    return res_time_string
+
+# helper function to ensure days of months get correct suffix added to them
+def format_day_of_month( day_int ):
+    if day_int <= 0 or day_int > 31:
+        return ""
+    
+    match day_int:
+        case 1:
+            return "1st"
+        case 2:
+            return "2nd"
+        case 3:
+            return "3rd"
+        case 21:
+            return "21st"
+        case 22:
+            return "22nd"
+        case 23:
+            return "23rd"
+        case 31:
+            return "31st"
+        case _:
+            return f"{day_int}th"
+        
+# Python's time library does not contain a built in way to trim leading 0s
+def format_hours_remove_leading_zero( hours_str ):
+    if not hours_str or not hours_str.isdecimal():
+        return ""
+    
+    hours_int = int(hours_str)
+
+    return f"{hours_int}"
+


### PR DESCRIPTION
I made the assumption that you didn't want to only display Unix epoch seconds on your webpage. I copied the formatting you had been using before on your posts, however this can be updated as you see fit.

<img width="368" alt="Screen Shot 2023-02-09 at 08 56 50" src="https://user-images.githubusercontent.com/91854538/217883983-6d642ede-c2ec-44bc-aa6e-fa12dcbcd24d.png">

I "modularized" this functionality. Meaning, instead of writing two separate functions in each of the creatures, writings classes, I wrote one single time handling module, that could be referenced and used by creatures, writings (and beyond).

It is best practice to break things apart and modularize as much as possible!

In the future, if you ever decide you want to format time differently, you only need to update the time formatting in ONE place, vs tracking down every unique time function which would happen if things weren't modularized.